### PR TITLE
Exposes TokenValidator func and JWTTokenValidator interface, updates

### DIFF
--- a/alice-example/main.go
+++ b/alice-example/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/emanoelxavier/openid2go/openid"
+	"github.com/TykTechnologies/openid2go/openid"
 	"github.com/gorilla/context"
 	"github.com/justinas/alice"
 )

--- a/gorilla-example/main.go
+++ b/gorilla-example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/emanoelxavier/openid2go/openid"
+	"github.com/TykTechnologies/openid2go/openid"
 	"github.com/gorilla/context"
 )
 

--- a/openid/httpclientmock_test.go
+++ b/openid/httpclientmock_test.go
@@ -63,9 +63,9 @@ func (c *HTTPClientMock) decodeResponse(reader io.Reader, value interface{}) err
 			v.Issuer = dr.value.(*configuration).Issuer
 			v.JwksUri = dr.value.(*configuration).JwksUri
 		}
-	case *jose.JsonWebKeySet:
+	case *jose.JSONWebKeySet:
 		if dr.value != nil {
-			v.Keys = dr.value.(*jose.JsonWebKeySet).Keys
+			v.Keys = dr.value.(*jose.JSONWebKeySet).Keys
 		}
 
 	default:

--- a/openid/idtokenvalidator.go
+++ b/openid/idtokenvalidator.go
@@ -12,7 +12,7 @@ const audiencesClaimName = "aud"
 const subjectClaimName = "sub"
 const keyIDJwtHeaderName = "kid"
 
-type jwtTokenValidator interface {
+type JWTTokenValidator interface {
 	validate(t string) (jt *jwt.Token, err error)
 }
 

--- a/openid/jwksgettermock_test.go
+++ b/openid/jwksgettermock_test.go
@@ -20,17 +20,17 @@ type getJwksCall struct {
 }
 
 type getJwksResponse struct {
-	jwks jose.JsonWebKeySet
+	jwks jose.JSONWebKeySet
 	err  error
 }
 
-func (c *jwksGetterMock) getJwkSet(url string) (jose.JsonWebKeySet, error) {
+func (c *jwksGetterMock) getJwkSet(url string) (jose.JSONWebKeySet, error) {
 	c.Calls <- &getJwksCall{url}
 	gr := (<-c.Calls).(*getJwksResponse)
 	return gr.jwks, gr.err
 }
 
-func (c *jwksGetterMock) assertGetJwks(url string, jwks jose.JsonWebKeySet, err error) {
+func (c *jwksGetterMock) assertGetJwks(url string, jwks jose.JSONWebKeySet, err error) {
 	call := (<-c.Calls).(*getJwksCall)
 	if url != anything && call.url != url {
 		c.t.Error("Expected getJwks with", url, "but was", call.url)

--- a/openid/jwksprovider.go
+++ b/openid/jwksprovider.go
@@ -8,7 +8,7 @@ import (
 )
 
 type jwksGetter interface {
-	getJwkSet(string) (jose.JsonWebKeySet, error)
+	getJwkSet(string) (jose.JSONWebKeySet, error)
 }
 
 type httpJwksProvider struct {
@@ -20,9 +20,9 @@ func newHTTPJwksProvider(gf httpGetFunc, df decodeResponseFunc) *httpJwksProvide
 	return &httpJwksProvider{gf, df}
 }
 
-func (httpProv *httpJwksProvider) getJwkSet(url string) (jose.JsonWebKeySet, error) {
+func (httpProv *httpJwksProvider) getJwkSet(url string) (jose.JSONWebKeySet, error) {
 
-	var jwks jose.JsonWebKeySet
+	var jwks jose.JSONWebKeySet
 	resp, err := httpProv.getJwks(url)
 
 	if err != nil {

--- a/openid/jwksprovider_test.go
+++ b/openid/jwksprovider_test.go
@@ -91,11 +91,11 @@ func Test_getJwkSet_WhenDecodeResponseReturnsError(t *testing.T) {
 func Test_getJwkSet_WhenDecodeResponseSucceeds(t *testing.T) {
 	c := NewHTTPClientMock(t)
 	jwksProvider := httpJwksProvider{c.httpGet, c.decodeResponse}
-	keys := []jose.JsonWebKey{
-		{"key1", "keyid1", "algo1", "use1"},
-		{"key2", "keyid2", "algo2", "use2"},
+	keys := []jose.JSONWebKey{
+		{Key: "key1", Certificates: nil, KeyID: "keyid1", Algorithm: "algo1", Use: "use1"},
+		{Key: "key2", Certificates: nil, KeyID: "keyid2", Algorithm: "algo2", Use: "use2"},
 	}
-	jwks := &jose.JsonWebKeySet{Keys: keys}
+	jwks := &jose.JSONWebKeySet{Keys: keys}
 	respBody := "jwk set"
 	resp := &http.Response{Body: testBody{bytes.NewBufferString(respBody)}}
 

--- a/openid/middleware.go
+++ b/openid/middleware.go
@@ -9,7 +9,7 @@ import (
 // The Configuration contains the entities needed to perform ID token validation.
 // This type should be instantiated at the application startup time.
 type Configuration struct {
-	tokenValidator jwtTokenValidator
+	tokenValidator JWTTokenValidator
 	idTokenGetter  GetIDTokenFunc
 	errorHandler   ErrorHandlerFunc
 }
@@ -44,6 +44,13 @@ func NewConfiguration(options ...option) (*Configuration, error) {
 func ProvidersGetter(pg GetProvidersFunc) func(*Configuration) error {
 	return func(c *Configuration) error {
 		c.tokenValidator.(*idTokenValidator).provGetter = pg
+		return nil
+	}
+}
+
+func TokenValidator(tv JWTTokenValidator) func(*Configuration) error {
+	return func(c *Configuration) error {
+		c.tokenValidator = tv
 		return nil
 	}
 }

--- a/openid/signingkeysetprovider_test.go
+++ b/openid/signingkeysetprovider_test.go
@@ -37,7 +37,7 @@ func Test_getsigningKeySet_WhenGetJwksReturnsError(t *testing.T) {
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
 		configGetter.close()
-		jwksGetter.assertGetJwks(anything, jose.JsonWebKeySet{}, ee)
+		jwksGetter.assertGetJwks(anything, jose.JSONWebKeySet{}, ee)
 		jwksGetter.close()
 
 	}()
@@ -62,7 +62,7 @@ func Test_getsigningKeySet_WhenJwkSetIsEmpty(t *testing.T) {
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
 		configGetter.close()
-		jwksGetter.assertGetJwks(anything, jose.JsonWebKeySet{}, nil)
+		jwksGetter.assertGetJwks(anything, jose.JSONWebKeySet{}, nil)
 		jwksGetter.close()
 
 	}()
@@ -83,7 +83,7 @@ func Test_getsigningKeySet_WhenKeyEncodingReturnsError(t *testing.T) {
 	configGetter, jwksGetter, pemEncoder, skProv := createSigningKeySetProvider(t)
 
 	ee := &ValidationError{Code: ValidationErrorMarshallingKey, HTTPStatus: http.StatusInternalServerError}
-	ejwks := jose.JsonWebKeySet{Keys: []jose.JsonWebKey{{Key: nil}}}
+	ejwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: nil}}}
 
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
@@ -110,15 +110,15 @@ func Test_getsigningKeySet_WhenKeyEncodingReturnsError(t *testing.T) {
 func Test_getsigningKeySet_WhenKeyEncodingReturnsSuccess(t *testing.T) {
 	configGetter, jwksGetter, pemEncoder, skProv := createSigningKeySetProvider(t)
 
-	keys := make([]jose.JsonWebKey, 2)
+	keys := make([]jose.JSONWebKey, 2)
 	encryptedKeys := make([]signingKey, 2)
 
 	for i := 0; i < cap(keys); i = i + 1 {
-		keys[i] = jose.JsonWebKey{KeyID: fmt.Sprintf("%v", i), Key: i}
+		keys[i] = jose.JSONWebKey{KeyID: fmt.Sprintf("%v", i), Key: i}
 		encryptedKeys[i] = signingKey{keyID: fmt.Sprintf("%v", i), key: []byte(fmt.Sprintf("%v", i))}
 	}
 
-	ejwks := jose.JsonWebKeySet{Keys: keys}
+	ejwks := jose.JSONWebKeySet{Keys: keys}
 	go func() {
 		configGetter.assertGetConfiguration(anything, configuration{}, nil)
 		jwksGetter.assertGetJwks(anything, ejwks, nil)


### PR DESCRIPTION
This brings in the change from one of the use cases we have for this library. It's been a part of the vendored version only, which obviously breaks easily and can't be tracked normally, so should be a part of the repo.
Also updates usage of go-jose as it changed Json* type names to all uppercase some time ago, which breaks things unless the application pins a specific version (which needs to be deduced).